### PR TITLE
Orgznie disk availability conditions

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -121,23 +121,24 @@ class DriveSelection(object):
         for disk in self.disks:
             logger.debug("Processing disk {}".format(disk.path))
 
-            if not disk.available and not disk.ceph_device:
-                logger.debug(
-                    ("Ignoring disk {}. "
-                     "Disk is unavailable due to {}".format(disk.path, disk.rejected_reasons))
-                )
-                continue
-
-            if not disk.available and disk.ceph_device and disk.lvs:
-                other_osdspec_affinity = ''
-                for lv in disk.lvs:
-                    if lv['osdspec_affinity'] != self.spec.service_id:
-                        other_osdspec_affinity = lv['osdspec_affinity']
-                        break
-                if other_osdspec_affinity:
-                    logger.debug("{} is already used in spec {}, "
-                                 "skipping it.".format(disk.path, other_osdspec_affinity))
+            if not disk.available:
+                if not disk.ceph_device:
+                    logger.debug(
+                            ("Ignoring disk {}. "
+                             "Disk is unavailable due to {}".format(disk.path, disk.rejected_reasons))
+                    )
                     continue
+
+                elif disk.lvs:
+                    other_osdspec_affinity = ''
+                    for lv in disk.lvs:
+                        if lv['osdspec_affinity'] != self.spec.service_id:
+                            other_osdspec_affinity = lv['osdspec_affinity']
+                            break
+                    if other_osdspec_affinity:
+                        logger.debug("{} is already used in spec {}, "
+                                     "skipping it.".format(disk.path, other_osdspec_affinity))
+                        continue         
 
             if not self._has_mandatory_idents(disk):
                 logger.debug(


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
